### PR TITLE
Add dependency injection to KeyManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+
+sudo: false
+
+install:
+  # Download Drupal.
+  - TESTDIR=$(pwd)
+  - cd ..
+  - git clone --branch 8.0.x --depth 1 http://git.drupal.org/project/drupal.git drupal
+  - cd drupal
+
+before_script:
+  # rsync the module directory into modules/
+  - rsync -rtlDPvc --exclude .git/ $TESTDIR modules/
+  - cd modules/key
+script:
+  - ../../core/vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,40 @@ php:
 
 sudo: false
 
+env:
+  global:
+    - PATH="$PATH:$HOME/.composer/vendor/bin"
+    - TESTDIR=$(pwd)
+    - DRUPAL_TI_MODULE_NAME="key"
+    - DRUPAL_TI_SIMPLETEST_GROUP="key"
+    - DRUPAL_TI_DB="drupal_travis_$$"
+    - DRUPAL_TI_DB_URL="mysql://root@127.0.0.1/$DRUPAL_TI_DB"
+    - DRUPAL_TI_WEBSERVER_URL="http://127.0.0.1"
+    - DRUPAL_TI_WEBSERVER_PORT="8080"
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT"
+    - DRUPAL_TI_PHPUNIT_CORE_SRC_DIRECTORY="./tests/src"
+    - DRUPAL_TI_ENVIRONMENT="drupal-8"
+
+  matrix:
+    - DRUPAL_TI_RUNNERS="simpletest phpunit-core"
+
+before_install:
+  - composer self-update
+  - composer global require "lionsad/drupal_ti:1.*"
+  - drupal-ti before_install
+
 install:
-  # Download Drupal.
-  - TESTDIR=$(pwd)
-  - cd ..
-  - git clone --branch 8.0.x --depth 1 http://git.drupal.org/project/drupal.git drupal
-  - cd drupal
+  - drupal-ti install
 
 before_script:
-  # rsync the module directory into modules/
-  - rsync -rtlDPvc --exclude .git/ $TESTDIR modules/
-  - cd modules/key
+  - drupal-ti before_script
+  - DRUPAL_TI_PHPUNIT_ARGS="-c $DRUPAL_TI_DRUPAL_DIR/modules/key/phpunit.xml --coverage-text"
+
 script:
-  - ../../core/vendor/bin/phpunit --coverage-text
+  - drupal-ti script
+
+after_script:
+  - drupal-ti after_script
+
+notifications:
+  email: false

--- a/key.services.yml
+++ b/key.services.yml
@@ -2,6 +2,7 @@ services:
 
   key_manager:
     class: Drupal\key\KeyManager
+    arguments: ['@entity.manager', '@config.factory']
 
   plugin.manager.key.key_type:
     class: Drupal\key\KeyTypePluginManager

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+  bootstrap="../../core/tests/bootstrap.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  verbose="true"
+>
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Key Module Unit Test Suite">
+      <directory>tests</directory>
+      <!-- Exclude Composer's vendor directory so we don't run tests there. -->
+      <exclude>./vendor</exclude>
+      <!-- Exclude Drush tests. -->
+      <exclude>./drush/tests</exclude>
+      <!-- Exclude special-case files from config's test modules. -->
+      <exclude>./modules/config/tests/config_test/src</exclude>
+    </testsuite>
+  </testsuites>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This module provides a global key management service that can be invoked via the
 ## Architecture
 
 Key leverages the Drupal 8 Plugin API for Key Types. Key Types define an interface to get key contents. Key Types have
-their own configuration forms that store key-type specific settings when creating a Key entity. 
+their own configuration forms that store key-type specific settings when creating a Key entity.
 
 Plugins allow for extensibility for customized needs. This allows other modules to create their own types of keys, the
 key type settings, and the logic for retrieving the key value.
@@ -17,6 +17,11 @@ To manage keys, visit `admin/config/system/key`.
 ## Use of Services
 
 After configuring the service, the service provides the ability to encrypt and decrypt.
+
+The Key Manager allows you to retrieve keys that your module uses. It is best practice to
+[inject the service](https://www.drupal.org/node/2133171) into your own service, [form](https://www.drupal.org/node/2203931),
+ or [controller](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!DependencyInjection!ContainerInjectionInterface.php/interface/ContainerInjectionInterface/8). The following examples assume the use of the `\Drupal` object for brevity, but the examples can be extrapolated to fit
+ the use case of your module.
 
 ### Get All Keys
 

--- a/src/Entity/Key.php
+++ b/src/Entity/Key.php
@@ -32,9 +32,9 @@ use Drupal\key\KeyInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "edit-form" = "entity.key.edit_form",
- *     "delete-form" = "entity.key.delete_form",
- *     "collection" = "entity.key.collection"
+ *     "edit-form" = "/admin/config/system/key/{key}/edit",
+ *     "delete-form" = "/admin/config/system/key/{key}/delete",
+ *     "collection" = "/admin/config/system/key"
  *   }
  * )
  */

--- a/src/KeyManager.php
+++ b/src/KeyManager.php
@@ -7,10 +7,27 @@
 
 namespace Drupal\key;
 
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+
 /**
  * Responsible for the key service.
  */
 class KeyManager {
+
+  /**
+   * Create the KeyManager.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
+   *   The entity manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(EntityManagerInterface $entityManager, ConfigFactoryInterface $configFactory) {
+    $this->entityManager = $entityManager;
+    $this->configFactory = $configFactory;
+  }
+
   /*
    * Loading a specific key.
    *
@@ -18,7 +35,7 @@ class KeyManager {
    *   The key ID to use.
    */
   public function getKeys() {
-    return \Drupal::entityManager()->getStorage('key')->loadMultiple();
+    return $this->entityManager->getStorage('key')->loadMultiple();
   }
 
   /*
@@ -28,7 +45,7 @@ class KeyManager {
    *   The key ID to use.
    */
   public function getKey($key_id) {
-    return \Drupal::entityManager()->getStorage('key')->load($key_id);
+    return $this->entityManager->getStorage('key')->load($key_id);
   }
 
   /*
@@ -38,16 +55,16 @@ class KeyManager {
    *   The key ID to use.
    */
   public function getKeyValue($key_id) {
-    return \Drupal::entityManager()->getStorage('key')->load($key_id)->getKeyValue();
+    return $this->entityManager->getStorage('key')->load($key_id)->getKeyValue();
   }
 
   /*
    * Loading the configured default key.
    */
   public function getDefaultKey() {
-    $key_id = \Drupal::config('key.default_config')->get('default_key');
+    $key_id = $this->configFactory->get('key.default_config')->get('default_key');
     if ($key_id) {
-      return \Drupal::entityManager()->getStorage('key')->load($key_id);
+      return $this->entityManager->getStorage('key')->load($key_id);
     }
     return NULL;
   }

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Provides \Drupal\Tests\key\KeyManagerTest.php
+ */
+
+namespace Drupal\Tests\key;
+
+use Drupal\key\Entity\Key;
+use Drupal\key\KeyManager;
+
+class KeyManagerTest extends KeyTestBase {
+
+
+  /**
+   * Test loading of default key entity.
+   */
+  public function testGetDefaultKey() {
+
+    $key_id = $this->getRandomGenerator()->word(15);
+    $key = new Key(['key_id' => $key_id], 'key');
+
+    // Mock load method to return when key is not defined and when it is
+    // defined.
+    $this->configStorage->expects($this->any())
+      ->method('load')
+      ->with($key_id)
+      ->will($this->onConsecutiveCalls(NULL, $key));
+
+    // Create a new key manager object.
+    $keyManager = new KeyManager($this->entityManager, $this->configFactory);
+
+    // On the first run, config storage will return NULL.
+    $default_key = $keyManager->getDefaultKey();
+    $this->assertEquals(NULL, $default_key);
+
+    // On the second run, config storage will return the key entity.
+    $default_key = $keyManager->getDefaultKey();
+    $this->assertEquals($key_id, $default_key->get('key_id'));
+  }
+
+}

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -29,6 +29,8 @@ class KeyManagerTest extends KeyTestBase {
 
   /**
    * Test load by multiple key ids.
+   *
+   * @group key
    */
   public function testGetKeys() {
     $key_id2 = $this->getRandomGenerator()->word(15);
@@ -45,6 +47,8 @@ class KeyManagerTest extends KeyTestBase {
 
   /**
    * Test load by key id.
+   *
+   * @group key
    */
   public function testGetKey() {
     $key = $this->keyManager->getKey($this->key_id);
@@ -54,6 +58,8 @@ class KeyManagerTest extends KeyTestBase {
 
   /**
    * Test get key value.
+   *
+   * @group key
    */
   public function testGetKeyValue() {
     // Create a key type plugin to play with.
@@ -79,6 +85,8 @@ class KeyManagerTest extends KeyTestBase {
 
   /**
    * Test loading of default key entity.
+   *
+   * @group key
    */
   public function testGetDefaultKey() {
     // On the first run, config storage will return NULL.
@@ -93,6 +101,8 @@ class KeyManagerTest extends KeyTestBase {
 
   /**
    * Test load of defaul key content.
+   *
+   * @group key
    *
    * @todo There is no Key::getContents() method so this will return an error.
    */

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -5,37 +5,132 @@
 
 namespace Drupal\Tests\key;
 
+use Drupal\key\Plugin\KeyType\SimpleKey;
 use Drupal\key\Entity\Key;
 use Drupal\key\KeyManager;
 
 class KeyManagerTest extends KeyTestBase {
 
+  /**
+   * @var \Drupal\key\KeyManager
+   */
+  protected $keyManager;
+
+  /**
+   * @var string
+   *   Random string to use as key id.
+   */
+  protected $key_id;
+
+  /**
+   * @var \Drupal\key\Entity\Key
+   */
+  protected $key;
+
+  /**
+   * Test load by multiple key ids.
+   */
+  public function testGetKeys() {
+    $key_id2 = $this->getRandomGenerator()->word(15);
+    $key2 = new Key(['key_id' => $key_id2], 'key');
+
+    $this->entityManager->expects($this->any())
+      ->method('loadMultiple')
+      ->with([$this->key_id, $key_id2])
+      ->willReturn([$this->key_id => $this->key, $key_id2 => $key2]);
+
+    $keys = $this->keyManager->getKeys([$this->key_id, $key_id2]);
+    $this->assertEquals(2, count($keys));
+  }
+
+  /**
+   * Test load by key id.
+   */
+  public function testGetKey() {
+    $key = $this->keyManager->getKey($this->key_id);
+    $this->assertInstanceOf('\Drupal\key\Entity\Key', $key);
+    $this->assertEquals($this->key->get('key_id'), $key->get('key_id'));
+  }
+
+  /**
+   * Test get key value.
+   */
+  public function testGetKeyValue() {
+    // Create a key type plugin to play with.
+    $defaults = ['simple_key_value' => $this->createToken()];
+    $definition = [
+      'id' => 'key_type_Simple',
+      'class' => 'Drupal\key\Plugin\KeyType\SimpleKey',
+      'title' => 'Simple Key',
+    ];
+    $keyType = new SimpleKey($defaults, 'key_type_simple', $definition);
+
+    // Make the key type plugin manager return a plugin instance.
+    $this->keyTypeManager->expects($this->any())
+      ->method('createInstance')
+      ->with('key_type_simple', $defaults)
+      ->willReturn($keyType);
+
+    $this->key->set('key_settings', $defaults);
+
+    $settings = $this->keyManager->getKeyValue($this->key_id);
+    $this->assertEquals($defaults['simple_key_value'], $settings);
+  }
 
   /**
    * Test loading of default key entity.
    */
   public function testGetDefaultKey() {
+    // On the first run, config storage will return NULL.
+    $default_key = $this->keyManager->getDefaultKey();
+    $this->assertEquals(NULL, $default_key);
 
-    $key_id = $this->getRandomGenerator()->word(15);
-    $key = new Key(['key_id' => $key_id], 'key');
+    // On the second run, config storage will return the key entity.
+    $default_key = $this->keyManager->getDefaultKey();
+    $this->assertInstanceOf('\Drupal\key\Entity\Key', $default_key);
+    $this->assertEquals($this->key_id, $default_key->get('key_id'));
+  }
+
+  /**
+   * Test load of defaul key content.
+   *
+   * @todo There is no Key::getContents() method so this will return an error.
+   */
+  public function testGetDefaultKeyContent() {
+
+    $content = $this->keyManager->getDefaultKeyContents();
+
+    $this->assertTrue(isset($content));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->key_id = $this->getRandomGenerator()->word(15);
+    $defaults = [
+      'key_id' => $this->key_id,
+      'key_type' => 'key_type_simple'
+    ];
+    $this->key = new Key($defaults, 'key');
+
+    // Mock the get method on the Config object.
+    $this->config->expects($this->any())
+      ->method('get')
+      ->with('default_key')
+      ->will($this->onConsecutiveCalls(FALSE, $this->key_id));
 
     // Mock load method to return when key is not defined and when it is
     // defined.
     $this->configStorage->expects($this->any())
       ->method('load')
-      ->with($key_id)
-      ->will($this->onConsecutiveCalls(NULL, $key));
+      ->with($this->key_id)
+      ->willReturn($this->key);
 
     // Create a new key manager object.
-    $keyManager = new KeyManager($this->entityManager, $this->configFactory);
-
-    // On the first run, config storage will return NULL.
-    $default_key = $keyManager->getDefaultKey();
-    $this->assertEquals(NULL, $default_key);
-
-    // On the second run, config storage will return the key entity.
-    $default_key = $keyManager->getDefaultKey();
-    $this->assertEquals($key_id, $default_key->get('key_id'));
+    $this->keyManager = new KeyManager($this->entityManager, $this->configFactory);
   }
 
 }

--- a/tests/src/KeyTestBase.php
+++ b/tests/src/KeyTestBase.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @file
+ * Provides \Drupal\Tests\key\KeyTestBase.php.
+ */
+
+namespace Drupal\Tests\key;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Tests\UnitTestCase;
+
+class KeyTestBase extends UnitTestCase {
+
+  /**
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * @var \Drupal\Core\Config\Entity\ConfigEntityStorage
+   */
+  protected $configStorage;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityManager
+   */
+  protected $entityManager;
+
+  /**
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * @var \Drupal\Core\DependencyInjection\ContainerBuilder
+   *
+   * This should be used sparingly by test cases to add to the conatiner as
+   * necessary for tests.
+   */
+  protected $container;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Mock the Config object, but methods will be mocked in the test class.
+    $this->config = $this->getMockBuilder('\Drupal\Core\Config\ImmutableConfig')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Mock the ConfigFactory service.
+    $this->configFactory = $this->getMockBuilder('\Drupal\Core\Config\ConfigFactory')
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->configFactory->expects($this->any())
+      ->method('get')
+      ->with('key.default_config')
+      ->willReturn($this->config);
+
+    // Mock ConfigEntityStorage object, but methods will be mocked in the test
+    // class.
+    $this->configStorage = $this->getMockBuilder('\Drupal\Core\Config\Entity\ConfigEntityStorage')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Mock EntityManager service.
+    $this->entityManager = $this->getMockBuilder('\Drupal\Core\Entity\EntityManager')
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->entityManager->expects($this->any())
+      ->method('getStorage')
+      ->with('key')
+      ->willReturn($this->configStorage);
+
+    // Create a dummy container.
+    $this->container = new ContainerBuilder();
+    $this->container->set('entity.manager', $this->entityManager);
+    $this->container->set('config.factory', $this->configFactory);
+    \Drupal::setContainer($this->container);
+  }
+
+}

--- a/tests/src/KeyTestBase.php
+++ b/tests/src/KeyTestBase.php
@@ -74,11 +74,27 @@ class KeyTestBase extends UnitTestCase {
       ->with('key')
       ->willReturn($this->configStorage);
 
+    // Mock the KeyTypePluginManager service.
+    $this->keyTypeManager = $this->getMockBuilder('\Drupal\key\KeyTypePluginManager')
+      ->disableOriginalConstructor()
+      ->getMock();
+
     // Create a dummy container.
     $this->container = new ContainerBuilder();
     $this->container->set('entity.manager', $this->entityManager);
     $this->container->set('config.factory', $this->configFactory);
+    $this->container->set('plugin.manager.key.key_type', $this->keyTypeManager);
     \Drupal::setContainer($this->container);
+  }
+
+  /**
+   * Return a token that could be a key.
+   *
+   * @return string
+   *   A hashed string that could be confused as some secret token.
+   */
+  protected function createToken() {
+    return strtoupper(hash('ripemd128', md5($this->getRandomGenerator()->string(30))));
   }
 
 }


### PR DESCRIPTION
This branch changes the KeyManager service to use dependency injection, and adds PHP Unit tests.

There are two failing tests due to code errors inside KeyManager:

1. getKeys() specifies a string argument but loadMultiple takes an array argument.
2. getDefaultKeyContents() uses a method getKeyContents but this does not exist.

I added phpunit.xml inside the module directory which is configured to use Drupal bootstrap like how I do it with [Xero](https://github.com/mradcliffe/xero). This allows to run unit tests like so:

**Updated**

Now uses drupal-ti to run both simpletest and phpunit tests.

https://travis-ci.org/mradcliffe/key/builds/73238879