### PR TITLE
Issue #15: Fix getKeys() method to expect an optional array argument,…

### DIFF
--- a/src/KeyManager.php
+++ b/src/KeyManager.php
@@ -34,9 +34,15 @@ class KeyManager {
 
   /*
    * Loading all keys.
+   *
+   * @param array $key_ids
+   *   (optional) An array of entity IDs, or NULL to load all entities.
+   * @return \Drupal\key\Entity\Key[]
+   *   An array of keys indexed by their IDs. Returns an empty array if no
+   *   matching entities are found.
    */
-  public function getKeys() {
-    return $this->entityManager->getStorage('key')->loadMultiple();
+  public function getKeys(array $key_ids = NULL) {
+    return $this->entityManager->getStorage('key')->loadMultiple($key_ids);
   }
 
   /*
@@ -63,8 +69,8 @@ class KeyManager {
     });
 
     $keys = [];
-    foreach ($key_types as $key_type_id => $key_type) {
-      $keys = array_merge($keys, $this->getKeysByType($key_type_id));
+    foreach ($key_types as $key_type) {
+      $keys = array_merge($keys, $this->getKeysByType($key_type['id']));
     }
     return $keys;
   }

--- a/tests/src/KeyTestBase.php
+++ b/tests/src/KeyTestBase.php
@@ -74,17 +74,14 @@ class KeyTestBase extends UnitTestCase {
       ->with('key')
       ->willReturn($this->configStorage);
 
-    // Mock the KeyTypePluginManager service.
-    $this->keyTypeManager = $this->getMockBuilder('\Drupal\key\KeyTypePluginManager')
-      ->disableOriginalConstructor()
-      ->getMock();
-
     // Create a dummy container.
     $this->container = new ContainerBuilder();
     $this->container->set('entity.manager', $this->entityManager);
     $this->container->set('config.factory', $this->configFactory);
-    $this->container->set('plugin.manager.key.key_type', $this->keyTypeManager);
-    \Drupal::setContainer($this->container);
+
+    // Each test class should call \Drupal::setContainer() in its own setUp
+    // method so that test classes can add mocked services to the container
+    // without affecting other test classes.
   }
 
   /**


### PR DESCRIPTION
… and add theoretical data provider in case getKeys changes in the future.

This uses a technique in phpunit called a data provider, which allows a test to accept parameters. The number of items in the array returned by the data provider will equal the number of times the test method is run.

I took a stab at fixing this by looking at the [EntityStorageBase](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Entity!EntityStorageBase.php/function/EntityStorageBase%3A%3AloadMultiple/8) documentation.