### PR TITLE
Keytype plugin tests

### DIFF
--- a/src/Plugin/KeyType/FileKey.php
+++ b/src/Plugin/KeyType/FileKey.php
@@ -78,6 +78,7 @@ class FileKey extends KeyTypeBase {
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $this->configuration['file_key_location'] = $form_state->getValue('file_key_location');
+    $this->configuration['file_key_method'] = $form_state->getValue('file_key_method');
   }
 
   /**

--- a/src/Plugin/KeyType/FileKey.php
+++ b/src/Plugin/KeyType/FileKey.php
@@ -39,8 +39,8 @@ class FileKey extends KeyTypeBase {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form['file_key_location'] = array(
       '#type' => 'textfield',
-      '#title' => t('Key Location'),
-      '#description' => t('The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).', array(
+      '#title' => $this->t('Key Location'),
+      '#description' => $this->t('The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).', array(
         '%abs' => '/etc/keys/foobar.key',
         '%rel' => '../keys/foobar.key',
         '%str' => 'private://keys/foobar.key',
@@ -50,11 +50,11 @@ class FileKey extends KeyTypeBase {
     );
     $form['file_key_method'] = array(
       '#type' => 'select',
-      '#title' => t('Method'),
-      '#description' => t('If the selected method is “File contents”, the contents of the file will be used as entered. If “MD5 hash” is selected, an MD5 hash of the file contents will be used as the key.'),
+      '#title' => $this->t('Method'),
+      '#description' => $this->t('If the selected method is “File contents”, the contents of the file will be used as entered. If “MD5 hash” is selected, an MD5 hash of the file contents will be used as the key.'),
       '#options' => array(
-        'file_contents' => t('File contents'),
-        'md5' => t('MD5 hash'),
+        'file_contents' => $this->t('File contents'),
+        'md5' => $this->t('MD5 hash'),
       ),
       '#default_value' => $this->getConfiguration()['file_key_method'],
     );

--- a/src/Plugin/KeyType/SimpleKey.php
+++ b/src/Plugin/KeyType/SimpleKey.php
@@ -38,8 +38,8 @@ class SimpleKey extends KeyTypeBase {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form['simple_key_value'] = array(
       '#type' => 'textarea',
-      '#title' => t('Key Value'),
-      '#description' => t('Enter the value of the key'),
+      '#title' => $this->t('Key Value'),
+      '#description' => $this->t('Enter the value of the key'),
       '#required' => TRUE,
       '#default_value' => $this->getConfiguration()['simple_key_value'],
     );

--- a/tests/src/KeyTypeTestBase.php
+++ b/tests/src/KeyTypeTestBase.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @file
+ * Provides \Drupal\Tests\key\KeyTypeTestBase
+ */
+
+namespace Drupal\Tests\key;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\Core\Form\FormTestBase;
+
+/**
+ * Provides a base form to test plugin form methods.
+ */
+abstract class KeyTypeTestBase extends FormTestBase {
+
+  /**
+   * @var \Drupal\Core\Form\FormState
+   */
+  protected $form_state;
+
+  /**
+   * @var \Drupal\key\KeyTypeInterface
+   */
+  protected $plugin;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Despite the protected variable being defined in FormTestBase it is not
+    // defined.
+    $this->translationManager = $this->getMockBuilder('Drupal\Core\StringTranslation\TranslationManager')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $this->container = new ContainerBuilder();
+    $this->container->set('string_translation', $this->translationManager);
+    \Drupal::setContainer($this->container);
+
+    $this->form_state = new FormState();
+    $definition = [
+      'id' => static::PLUGIN_ID,
+      'title' => static::PLUGIN_TITLE,
+      'storage_method' => static::PLUGIN_STORAGE
+    ];
+
+    $plugin_class = static::PLUGIN_CLASS;
+    $this->plugin = new $plugin_class([], static::PLUGIN_ID, $definition);
+  }
+}

--- a/tests/src/Plugin/KeyType/FileKeyTest.php
+++ b/tests/src/Plugin/KeyType/FileKeyTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @file
+ * Provides \Drupal\Tests\key\Plugin\KeyType\FileKeyTest
+ */
+
+namespace Drupal\Tests\key\Plugin\KeyType;
+
+use Drupal\Tests\key\KeyTypeTestBase;
+
+/**
+ * Test the FileKey plugin.
+ */
+class FileKeyTest extends KeyTypeTestBase {
+
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyType\FileKey';
+  const PLUGIN_ID = 'key_type_file';
+  const PLUGIN_TITLE = 'File Key';
+  const PLUGIN_STORAGE = 'file';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Create a private key.
+    $output = '';
+    $this->keyFile = sys_get_temp_dir() . $this->getRandomGenerator()->word(10) . '.key';
+    $resource = openssl_pkey_new(['digest_alg' => 'sha1', 'private_key_bits' => 1024, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    openssl_pkey_export($resource, $output);
+
+    file_put_contents($this->keyFile, $output);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown() {
+    if (file_exists($this->keyFile)) {
+      unlink($this->keyFile);
+    }
+
+    parent::tearDown();
+  }
+
+  /**
+   * Test the plugin configuration form when using file contents method.
+   *
+   * @group key
+   */
+  public function testFileContentsKey() {
+    $form = [];
+
+    // Mock the translation manager translate method. This test does not assert
+    // any other translation messages so the return value will always be the
+    // same message on each consecutive call to t().
+    $this->translationManager->expects($this->any())
+      ->method('translate')
+      ->withConsecutive(
+        ['Key Location'],
+        ['The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).'],
+        ['Method'],
+        ['If the selected method is “File contents”, the contents of the file will be used as entered. If “MD5 hash” is selected, an MD5 hash of the file contents will be used as the key.'],
+        ['File contents'],
+        ['MD5 hash'],
+        ['File does not exist or is not readable.']
+      )
+      ->willReturn('File does not exist or is not readable.');
+
+    $form['key_settings'] = $this->plugin->buildConfigurationForm($form, $this->form_state);
+    $this->assertNotNull($form['key_settings']['file_key_location']);
+    $this->assertNotNull($form['key_settings']['file_key_method']);
+
+    // Test that the file is validated.
+    $this->form_state->setValues(['file_key_location' => 'bogus', 'file_key_method' => 'file_contents']);
+    $this->plugin->validateConfigurationForm($form, $this->form_state);
+    $this->assertEquals('File does not exist or is not readable.', $this->form_state->getErrors()['file_key_location']);
+
+    // Set the form state value, and simulate a form submission.
+    $this->form_state->clearErrors();
+    $this->form_state->setValues(['file_key_location' => $this->keyFile, 'file_key_method' => 'file_contents']);
+    $this->plugin->validateConfigurationForm($form, $this->form_state);
+    $this->assertEmpty($this->form_state->getErrors());
+
+    // Submission.
+    $this->plugin->submitConfigurationForm($form, $this->form_state);
+    $this->assertEquals($this->keyFile, $this->plugin->getConfiguration()['file_key_location']);
+    $this->assertEquals('file_contents', $this->plugin->getConfiguration()['file_key_method']);
+
+    // Make sure that the file contents are valid.
+    $resource = openssl_pkey_get_private($this->plugin->getKeyValue());
+    $this->assertNotFalse($resource);
+  }
+
+  /**
+   * Test the plugin for MD5 hash storage.
+   *
+   * @group key
+   */
+  public function testMD5Key() {
+    $form = [];
+
+    $form['key_settings'] = $this->plugin->buildConfigurationForm($form, $this->form_state);
+
+    // Set the form state value, and simulate a form submission.
+    $this->form_state->setValues(['file_key_location' => $this->keyFile, 'file_key_method' => 'md5']);
+    $this->plugin->validateConfigurationForm($form, $this->form_state);
+    $this->assertEmpty($this->form_state->getErrors());
+
+    // Submission.
+    $this->plugin->submitConfigurationForm($form, $this->form_state);
+    $this->assertEquals($this->keyFile, $this->plugin->getConfiguration()['file_key_location']);
+    $this->assertEquals('md5', $this->plugin->getConfiguration()['file_key_method']);
+
+    // Make sure that the md5 hash is valid.
+    $this->assertEquals(md5_file($this->keyFile), $this->plugin->getKeyValue());
+  }
+}

--- a/tests/src/Plugin/KeyType/FileKeyTest.php
+++ b/tests/src/Plugin/KeyType/FileKeyTest.php
@@ -26,7 +26,7 @@ class FileKeyTest extends KeyTypeTestBase {
 
     // Create a private key.
     $output = '';
-    $this->keyFile = sys_get_temp_dir() . $this->getRandomGenerator()->word(10) . '.key';
+    $this->keyFile = sys_get_temp_dir() . '/' . $this->getRandomGenerator()->word(10) . '.key';
     $resource = openssl_pkey_new(['digest_alg' => 'sha1', 'private_key_bits' => 1024, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
     openssl_pkey_export($resource, $output);
 

--- a/tests/src/Plugin/KeyType/SimpleKeyTest.php
+++ b/tests/src/Plugin/KeyType/SimpleKeyTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @file
+ * Provides \Drupal\Tests\key\Plugin\KeyType\SimpleKeyTest
+ */
+
+namespace Drupal\Tests\key\Plugin\KeyType;
+
+use Drupal\Tests\key\KeyTypeTestBase;
+
+/**
+ * Test the SimpleKey plugin.
+ */
+class SimpleKeyTest extends KeyTypeTestBase {
+
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyType\SimpleKey';
+  const PLUGIN_ID = 'key_type_simple';
+  const PLUGIN_TITLE = 'Simple Key';
+  const PLUGIN_STORAGE = 'config';
+
+  /**
+   * Test the plugin configuration form.
+   *
+   * @group key
+   */
+  public function testPluginForm() {
+    $value = $this->getRandomGenerator()->word(10);
+    $form = [];
+
+    $form['key_settings'] = $this->plugin->buildConfigurationForm($form, $this->form_state);
+    $this->assertNotNull($form['key_settings']['simple_key_value']);
+    $this->assertEmpty($form['key_settings']['simple_key_value']['#default_value']);
+
+    // Set the form state value, and simulate a form submission.
+    $this->form_state->setValues(['simple_key_value' => $value]);
+    $this->plugin->validateConfigurationForm($form, $this->form_state);
+    $this->assertEmpty($this->form_state->getErrors());
+
+    // Submission.
+    $this->plugin->submitConfigurationForm($form, $this->form_state);
+    $this->assertEquals($value, $this->plugin->getConfiguration()['simple_key_value']);
+  }
+}


### PR DESCRIPTION
I added key type plugin tests which uncovered a couple of issues:

1. Switch to using $this->t() instead of global t() function.
2. Fix file_key_method to actually be used when it is set.

```
Code Coverage Report:     
  2015-08-07 14:03:19     
                          
 Summary:                 
  Classes: 25.00% (3/12)  
  Methods: 44.68% (21/47) 
  Lines:   28.95% (88/304)

\Drupal\key::KeyManager
  Methods: 100.00% ( 8/ 8)   Lines: 100.00% ( 19/ 19)
\Drupal\key::KeyTypeBase
  Methods:  60.00% ( 3/ 5)   Lines:  77.78% (  7/  9)
\Drupal\key\Entity::Key
  Methods:  33.33% ( 1/ 3)   Lines:  60.00% (  3/  5)
\Drupal\key\Plugin\KeyType::FileKey
  Methods:  80.00% ( 4/ 5)   Lines:  93.18% ( 41/ 44)
\Drupal\key\Plugin\KeyType::SimpleKey
  Methods: 100.00% ( 5/ 5)   Lines: 100.00% ( 13/ 13)
```