### PR TITLE
Changed plugin name from Key Type to Key Provider.

### DIFF
--- a/config/schema/key.schema.yml
+++ b/config/schema/key.schema.yml
@@ -10,34 +10,34 @@ key.key.*:
       label: 'Label'
     uuid:
       type: string
-    key_type:
+    key_provider:
       type: string
-      label: Key Type
+      label: Key Provider
     key_settings:
-      type: key.key_type.plugin.[id]
+      type: key.key_provider.plugin.[id]
       label: 'Key Settings'
 
-key_type:
+key_provider:
   type: mapping
-  label: 'Key type settings'
+  label: 'Key provider settings'
   mapping:
     id:
       type: string
       label: 'ID'
 
-key.key_type.plugin.*:
-  type: key_type
+key.key_provider.plugin.*:
+  type: key_provider
 
-key.key_type.plugin.key_type_simple:
-  type: key_type
+key.key_provider.plugin.key_provider_simple:
+  type: key_provider
   label: 'Simple Key'
   mapping:
     simple_key_value:
       type: string
       label: 'Key Value'
 
-key.key_type.plugin.key_type_file:
-  type: key_type
+key.key_provider.plugin.key_provider_file:
+  type: key_provider
   label: 'Simple Key'
   mapping:
     file_key_location:

--- a/key.services.yml
+++ b/key.services.yml
@@ -2,8 +2,8 @@ services:
 
   key_manager:
     class: Drupal\key\KeyManager
-    arguments: ['@entity.manager', '@config.factory', '@plugin.manager.key.key_type']
+    arguments: ['@entity.manager', '@config.factory', '@plugin.manager.key.key_provider']
 
-  plugin.manager.key.key_type:
-    class: Drupal\key\KeyTypePluginManager
+  plugin.manager.key.key_provider:
+    class: Drupal\key\KeyProviderPluginManager
     parent: default_plugin_manager

--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,11 @@ This module provides a global key management service that can be invoked via the
 
 ## Architecture
 
-Key leverages the Drupal 8 Plugin API for Key Types. Key Types define an interface to get key contents. Key Types have
-their own configuration forms that store key-type specific settings when creating a Key entity.
+Key leverages the Drupal 8 Plugin API for Key Providers. Key Providers define an interface to get key contents. Key Providers have
+their own configuration forms that store settings specific to that Key Provider when creating a Key entity.
 
-Plugins allow for extensibility for customized needs. This allows other modules to create their own types of keys, the
-key type settings, and the logic for retrieving the key value.
+Plugins allow for extensibility for customized needs. This allows other modules to create their own key providers, the
+key provider settings, and the logic for retrieving the key value.
 
 ## Settings
 

--- a/src/Annotation/KeyProvider.php
+++ b/src/Annotation/KeyProvider.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\key\Annotation\KeyType.
+ * Contains Drupal\key\Annotation\KeyProvider.
  */
 
 namespace Drupal\key\Annotation;
@@ -10,11 +10,11 @@ namespace Drupal\key\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines a key type annotation object.
+ * Defines a key provider annotation object.
  *
  * @Annotation
  */
-class KeyType extends Plugin {
+class KeyProvider extends Plugin {
 
   /**
    * The plugin ID.
@@ -42,7 +42,7 @@ class KeyType extends Plugin {
   public $description;
 
   /**
-   * The storage method of the key type.
+   * The storage method of the key provider.
    *
    * This is an enumeration of {file, config, database, remote}
    *

--- a/src/Entity/Key.php
+++ b/src/Entity/Key.php
@@ -53,12 +53,12 @@ class Key extends ConfigEntityBase implements KeyInterface {
    */
   protected $label;
 
-  protected $key_type;
+  protected $key_provider;
 
   protected $key_settings = [];
 
-  public function getKeyType() {
-    return $this->key_type;
+  public function getKeyProvider() {
+    return $this->key_provider;
   }
 
   public function getKeySettings() {
@@ -70,11 +70,11 @@ class Key extends ConfigEntityBase implements KeyInterface {
    */
   public function getKeyValue(){
     // Create instance of the plugin.
-    $plugin = \Drupal::service('plugin.manager.key.key_type');
-    $key_type = $plugin->createInstance($this->key_type, $this->key_settings);
+    $plugin = \Drupal::service('plugin.manager.key.key_provider');
+    $key_provider = $plugin->createInstance($this->key_provider, $this->key_settings);
 
     // Return it's key contents.
-    return $key_type->getKeyValue();
+    return $key_provider->getKeyValue();
   }
 
 }

--- a/src/KeyInterface.php
+++ b/src/KeyInterface.php
@@ -19,7 +19,7 @@ interface KeyInterface extends ConfigEntityInterface {
    *
    * @return string
    */
-  public function getKeyType();
+  public function getKeyProvider();
 
   /**
    * The plugin configuration for the selected key.

--- a/src/KeyManager.php
+++ b/src/KeyManager.php
@@ -46,31 +46,31 @@ class KeyManager {
   }
 
   /*
-   * Loading keys that are of the specified key type.
+   * Loading keys that are of the specified key provider.
    *
-   * @param string $key_type
-   *   The key type ID to use.
+   * @param string $key_provider
+   *   The key provider ID to use.
    */
-  public function getKeysByType($key_type_id) {
-    return $this->entityManager->getStorage('key')->loadByProperties(array('key_type' => $key_type_id));
+  public function getKeysByProvider($key_provider_id) {
+    return $this->entityManager->getStorage('key')->loadByProperties(array('key_provider' => $key_provider_id));
   }
 
   /*
    * Loading keys that are of the specified storage method.
    *
-   * Storage method is an annotation of a key's key type.
+   * Storage method is an annotation of a key's key provider.
    *
    * @param string $storage_method
-   *   The storage method of the key type.
+   *   The storage method of the key provider.
    */
   public function getKeysByStorageMethod($storage_method) {
-    $key_types = array_filter($this->pluginManager->getDefinitions(), function ($definition) use ($storage_method) {
+    $key_providers = array_filter($this->pluginManager->getDefinitions(), function ($definition) use ($storage_method) {
       return $definition['storage_method'] == $storage_method;
     });
 
     $keys = [];
-    foreach ($key_types as $key_type) {
-      $keys = array_merge($keys, $this->getKeysByType($key_type['id']));
+    foreach ($key_providers as $key_provider) {
+      $keys = array_merge($keys, $this->getKeysByProvider($key_provider['id']));
     }
     return $keys;
   }

--- a/src/KeyProviderBase.php
+++ b/src/KeyProviderBase.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Provides Drupal\key\KeyTypeBase.
+ * Provides Drupal\key\KeyProviderBase.
  */
 
 namespace Drupal\key;
@@ -10,7 +10,7 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 
-abstract class KeyTypeBase extends PluginBase implements KeyTypeInterface {
+abstract class KeyProviderBase extends PluginBase implements KeyProviderInterface {
   use StringTranslationTrait;
 
   /**

--- a/src/KeyProviderInterface.php
+++ b/src/KeyProviderInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\key\KeyTypeInterface.
+ * Contains Drupal\key\KeyProviderInterface.
  */
 
 namespace Drupal\key;
@@ -12,12 +12,12 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 
 /**
- * Provides an interface defining a Key Type plugin.
+ * Provides an interface defining a Key Provider plugin.
  */
-interface KeyTypeInterface extends PluginInspectionInterface, ConfigurablePluginInterface, PluginFormInterface {
+interface KeyProviderInterface extends PluginInspectionInterface, ConfigurablePluginInterface, PluginFormInterface {
 
   /**
-   * Returns the value of a key from the key type.
+   * Returns the value of a key from the key provider.
    * @return string
    */
   public function getKeyValue();

--- a/src/KeyProviderPluginManager.php
+++ b/src/KeyProviderPluginManager.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Contains Drupal\key\KeyTypePluginManager.
+ * Contains Drupal\key\KeyProviderPluginManager.
  */
 
 namespace Drupal\key;
@@ -10,9 +10,9 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
 
-class KeyTypePluginManager extends \Drupal\Core\Plugin\DefaultPluginManager {
+class KeyProviderPluginManager extends \Drupal\Core\Plugin\DefaultPluginManager {
   /**
-   * Constructs a new KeyTypePluginManager.
+   * Constructs a new KeyProviderPluginManager.
    *
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths
@@ -23,9 +23,9 @@ class KeyTypePluginManager extends \Drupal\Core\Plugin\DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/KeyType', $namespaces, $module_handler, 'Drupal\key\KeyTypeInterface', 'Drupal\key\Annotation\KeyType');
+    parent::__construct('Plugin/KeyProvider', $namespaces, $module_handler, 'Drupal\key\KeyProviderInterface', 'Drupal\key\Annotation\KeyProvider');
     $this->alterInfo('key_constraint_info');
-    $this->setCacheBackend($cache_backend, 'key_type');
+    $this->setCacheBackend($cache_backend, 'key_provider');
   }
 
 }

--- a/src/Plugin/KeyProvider/FileKey.php
+++ b/src/Plugin/KeyProvider/FileKey.php
@@ -2,26 +2,26 @@
 
 /**
  * @file
- * Contains Drupal\key\KeyType\FileKey.
+ * Contains Drupal\key\KeyProvider\FileKey.
  */
 
 
-namespace Drupal\key\Plugin\KeyType;
+namespace Drupal\key\Plugin\KeyProvider;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\key\KeyTypeBase;
+use Drupal\key\KeyProviderBase;
 
 /**
  * Enforces a number of a type of character in passwords.
  *
- * @KeyType(
- *   id = "key_type_file",
+ * @KeyProvider(
+ *   id = "key_provider_file",
  *   title = @Translation("File Key"),
- *   description = @Translation("This key type is stored within a file in the filesystem."),
+ *   description = @Translation("This key provider is stored within a file in the filesystem."),
  *   storage_method = "file",
  * )
  */
-class FileKey extends KeyTypeBase {
+class FileKey extends KeyProviderBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/KeyProvider/SimpleKey.php
+++ b/src/Plugin/KeyProvider/SimpleKey.php
@@ -2,26 +2,26 @@
 
 /**
  * @file
- * Contains Drupal\key\KeyType\SimpleKey.
+ * Contains Drupal\key\KeyProvider\SimpleKey.
  */
 
 
-namespace Drupal\key\Plugin\KeyType;
+namespace Drupal\key\Plugin\KeyProvider;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\key\KeyTypeBase;
+use Drupal\key\KeyProviderBase;
 
 /**
  * Enforces a number of a type of character in passwords.
  *
- * @KeyType(
- *   id = "key_type_simple",
+ * @KeyProvider(
+ *   id = "key_provider_simple",
  *   title = @Translation("Simple Key"),
- *   description = @Translation("This key type is stored within the Drupal database."),
+ *   description = @Translation("This key provider is stored within the Drupal database."),
  *   storage_method = "config",
  * )
  */
-class SimpleKey extends KeyTypeBase {
+class SimpleKey extends KeyProviderBase {
 
   /**
    * {@inheritdoc}

--- a/src/Tests/KeyService.php
+++ b/src/Tests/KeyService.php
@@ -31,14 +31,14 @@ class KeyService extends WebTestBase {
     $test_string = 'testing 123 &*#';
     $this->drupalGet('admin/config/system/key/add');
     $edit = [
-      'key_type' => 'key_type_simple',
+      'key_provider' => 'key_provider_simple',
     ];
-    $this->drupalPostAjaxForm(NULL, $edit, 'key_type');
+    $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key',
       'label' => 'Testing Key',
-      'key_type' => 'key_type_simple',
+      'key_provider' => 'key_provider_simple',
       'key_settings[simple_key_value]' => $test_string,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
@@ -51,29 +51,29 @@ class KeyService extends WebTestBase {
 
     $this->assertEqual($key_value_string, $test_string, 'The getKeyValue function is not properly processing');
 
-    // Test getKeysByType service.
-    $keys = \Drupal::service('key_manager')->getKeysByType('key_type_simple');
-    $this->assertEqual(count($keys), '1', 'The getKeysByType function is not returning 1 simple key');
+    // Test getKeysByProvider service.
+    $keys = \Drupal::service('key_manager')->getKeysByProvider('key_provider_simple');
+    $this->assertEqual(count($keys), '1', 'The getKeysByProvider function is not returning 1 simple key');
 
     // Create another simple key.
     $test_string = 'testing 12345678 (837#';
     $this->drupalGet('admin/config/system/key/add');
     $edit = [
-      'key_type' => 'key_type_simple',
+      'key_provider' => 'key_provider_simple',
     ];
-    $this->drupalPostAjaxForm(NULL, $edit, 'key_type');
+    $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key2',
       'label' => 'Testing Key 2',
-      'key_type' => 'key_type_simple',
+      'key_provider' => 'key_provider_simple',
       'key_settings[simple_key_value]' => $test_string,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
-    // Test getKeysByType service.
-    $keys = \Drupal::service('key_manager')->getKeysByType('key_type_simple');
-    $this->assertEqual(count($keys), '2', 'The getKeysByType function is not returning 2 simple keys');
+    // Test getKeysByProvider service.
+    $keys = \Drupal::service('key_manager')->getKeysByProvider('key_provider_simple');
+    $this->assertEqual(count($keys), '2', 'The getKeysByProvider function is not returning 2 simple keys');
   }
 
   /**
@@ -90,14 +90,14 @@ class KeyService extends WebTestBase {
     // Create a new file key.
     $this->drupalGet('admin/config/system/key/add');
     $edit = [
-      'key_type' => 'key_type_file',
+      'key_provider' => 'key_provider_file',
     ];
-    $this->drupalPostAjaxForm(NULL, $edit, 'key_type');
+    $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key_file',
       'label' => 'Testing Key File',
-      'key_type' => 'key_type_file',
+      'key_provider' => 'key_provider_file',
       'key_settings[file_key_location]' => $rpath,
       'key_settings[file_key_method]' => 'file_contents',
     ];
@@ -117,14 +117,14 @@ class KeyService extends WebTestBase {
     // Create a second new file key.
     $this->drupalGet('admin/config/system/key/add');
     $edit = [
-      'key_type' => 'key_type_file',
+      'key_provider' => 'key_provider_file',
     ];
-    $this->drupalPostAjaxForm(NULL, $edit, 'key_type');
+    $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key_file2',
       'label' => 'Testing Key File2',
-      'key_type' => 'key_type_file',
+      'key_provider' => 'key_provider_file',
       'key_settings[file_key_location]' => $rpath,
       'key_settings[file_key_method]' => 'file_contents',
     ];

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -5,7 +5,7 @@
 
 namespace Drupal\Tests\key;
 
-use Drupal\key\Plugin\KeyType\SimpleKey;
+use Drupal\key\Plugin\KeyProvider\SimpleKey;
 use Drupal\key\Entity\Key;
 use Drupal\key\KeyManager;
 
@@ -33,14 +33,14 @@ class KeyManagerTest extends KeyTestBase {
   public function defaultKeyContentProvider() {
     $defaults = ['simple_key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_type_Simple',
-      'class' => 'Drupal\key\Plugin\KeyType\SimpleKey',
+      'id' => 'key_provider_Simple',
+      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
       'title' => 'Simple Key',
     ];
-    $keyType = new SimpleKey($defaults, 'key_type_simple', $definition);
+    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
 
     return [
-      [$defaults, $keyType]
+      [$defaults, $KeyProvider]
     ];
   }
 
@@ -99,12 +99,12 @@ class KeyManagerTest extends KeyTestBase {
    * @group key
    * @dataProvider defaultKeyContentProvider
    */
-  public function testGetKeyValue($defaults, $keyType) {
-    // Make the key type plugin manager return a plugin instance.
-    $this->keyTypeManager->expects($this->any())
+  public function testGetKeyValue($defaults, $KeyProvider) {
+    // Make the key provider plugin manager return a plugin instance.
+    $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_type_simple', $defaults)
-      ->willReturn($keyType);
+      ->with('key_provider_simple', $defaults)
+      ->willReturn($KeyProvider);
 
     $this->key->set('key_settings', $defaults);
 
@@ -134,16 +134,16 @@ class KeyManagerTest extends KeyTestBase {
    * @group key
    * @dataProvider defaultKeyContentProvider
    */
-  public function testGetDefaultKeyContent($defaults, $keyType) {
+  public function testGetDefaultKeyContent($defaults, $KeyProvider) {
     // On the first run, config storage will return NULL.
     $settings = $this->keyManager->getDefaultKeyContents();
     $this->assertEquals(NULL, $settings);
 
-    // Make the key type plugin manager return a plugin instance.
-    $this->keyTypeManager->expects($this->any())
+    // Make the key provider plugin manager return a plugin instance.
+    $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_type_simple', $defaults)
-      ->willReturn($keyType);
+      ->with('key_provider_simple', $defaults)
+      ->willReturn($KeyProvider);
 
     $this->key->set('key_settings', $defaults);
 
@@ -152,35 +152,35 @@ class KeyManagerTest extends KeyTestBase {
   }
 
   /**
-   * Test get keys by type.
+   * Test get keys by provider.
    *
    * @group key
    */
-  public function testGetKeysByType() {
-    // Create a key type plugin to play with.
+  public function testgetKeysByProvider() {
+    // Create a key provider plugin to play with.
     $defaults = ['simple_key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_type_Simple',
-      'class' => 'Drupal\key\Plugin\KeyType\SimpleKey',
+      'id' => 'key_provider_Simple',
+      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
       'title' => 'Simple Key',
     ];
-    $keyType = new SimpleKey($defaults, 'key_type_simple', $definition);
+    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
 
-    // Make the key type plugin manager return a plugin instance.
-    $this->keyTypeManager->expects($this->any())
+    // Make the key provider plugin manager return a plugin instance.
+    $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_type_simple', $defaults)
-      ->willReturn($keyType);
+      ->with('key_provider_simple', $defaults)
+      ->willReturn($KeyProvider);
 
     // Mock the loadByProperties method in entity manager.
     $this->configStorage->expects($this->any())
       ->method('loadByProperties')
-      ->with(['key_type' => 'key_type_simple'])
+      ->with(['key_provider' => 'key_provider_simple'])
       ->willReturn([$this->key_id => $this->key]);
 
     $this->key->set('key_settings', $defaults);
 
-    $keys = $this->keyManager->getKeysByType('key_type_simple');
+    $keys = $this->keyManager->getKeysByProvider('key_provider_simple');
     $this->assertEquals($this->key, $keys[$this->key_id]);
   }
 
@@ -190,26 +190,26 @@ class KeyManagerTest extends KeyTestBase {
    * @group key
    */
   public function testGetKeysByStorageMethod() {
-    // Create a key type plugin to play with.
+    // Create a key provider plugin to play with.
     $defaults = ['simple_key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_type_Simple',
-      'class' => 'Drupal\key\Plugin\KeyType\SimpleKey',
+      'id' => 'key_provider_Simple',
+      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
       'title' => 'Simple Key',
     ];
-    $keyType = new SimpleKey($defaults, 'key_type_simple', $definition);
+    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
 
     // Mock the loadByProperties method in entity manager.
     $this->configStorage->expects($this->any())
       ->method('loadByProperties')
-      ->with(['key_type' => 'key_type_simple'])
+      ->with(['key_provider' => 'key_provider_simple'])
       ->willReturn([$this->key_id => $this->key]);
 
-    // Make the key type plugin manager return a plugin instance.
-    $this->keyTypeManager->expects($this->any())
+    // Make the key provider plugin manager return a plugin instance.
+    $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_type_simple', $defaults)
-      ->willReturn($keyType);
+      ->with('key_provider_simple', $defaults)
+      ->willReturn($KeyProvider);
 
     $this->key->set('key_settings', $defaults);
 
@@ -226,7 +226,7 @@ class KeyManagerTest extends KeyTestBase {
     $this->key_id = $this->getRandomGenerator()->word(15);
     $defaults = [
       'key_id' => $this->key_id,
-      'key_type' => 'key_type_simple'
+      'key_provider' => 'key_provider_simple'
     ];
     $this->key = new Key($defaults, 'key');
 
@@ -243,23 +243,23 @@ class KeyManagerTest extends KeyTestBase {
       ->with($this->key_id)
       ->willReturn($this->key);
 
-    // Mock the KeyTypePluginManager service.
-    $this->keyTypeManager = $this->getMockBuilder('\Drupal\key\KeyTypePluginManager')
+    // Mock the KeyProviderPluginManager service.
+    $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderPluginManager')
       ->disableOriginalConstructor()
       ->getMock();
 
-    $this->keyTypeManager->expects($this->any())
+    $this->KeyProviderManager->expects($this->any())
       ->method('getDefinitions')
       ->willReturn([
-        ['id' => 'key_type_file', 'title' => 'File Key', 'storage_method' => 'file'],
-        ['id' => 'key_type_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
+        ['id' => 'key_provider_file', 'title' => 'File Key', 'storage_method' => 'file'],
+        ['id' => 'key_provider_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
       ]);
 
-    $this->container->set('plugin.manager.key.key_type', $this->keyTypeManager);
+    $this->container->set('plugin.manager.key.key_provider', $this->KeyProviderManager);
     \Drupal::setContainer($this->container);
 
     // Create a new key manager object.
-    $this->keyManager = new KeyManager($this->entityManager, $this->configFactory, $this->keyTypeManager);
+    $this->keyManager = new KeyManager($this->entityManager, $this->configFactory, $this->KeyProviderManager);
   }
 
 }

--- a/tests/src/KeyProviderTestBase.php
+++ b/tests/src/KeyProviderTestBase.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Provides \Drupal\Tests\key\KeyTypeTestBase
+ * Provides \Drupal\Tests\key\KeyProviderTestBase
  */
 
 namespace Drupal\Tests\key;
@@ -13,7 +13,7 @@ use Drupal\Tests\Core\Form\FormTestBase;
 /**
  * Provides a base form to test plugin form methods.
  */
-abstract class KeyTypeTestBase extends FormTestBase {
+abstract class KeyProviderTestBase extends FormTestBase {
 
   /**
    * @var \Drupal\Core\Form\FormState
@@ -21,7 +21,7 @@ abstract class KeyTypeTestBase extends FormTestBase {
   protected $form_state;
 
   /**
-   * @var \Drupal\key\KeyTypeInterface
+   * @var \Drupal\key\KeyProviderInterface
    */
   protected $plugin;
 

--- a/tests/src/Plugin/KeyProvider/FileKeyTest.php
+++ b/tests/src/Plugin/KeyProvider/FileKeyTest.php
@@ -1,20 +1,20 @@
 <?php
 /**
  * @file
- * Provides \Drupal\Tests\key\Plugin\KeyType\FileKeyTest
+ * Provides \Drupal\Tests\key\Plugin\KeyProvider\FileKeyTest
  */
 
-namespace Drupal\Tests\key\Plugin\KeyType;
+namespace Drupal\Tests\key\Plugin\KeyProvider;
 
-use Drupal\Tests\key\KeyTypeTestBase;
+use Drupal\Tests\key\KeyProviderTestBase;
 
 /**
  * Test the FileKey plugin.
  */
-class FileKeyTest extends KeyTypeTestBase {
+class FileKeyTest extends KeyProviderTestBase {
 
-  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyType\FileKey';
-  const PLUGIN_ID = 'key_type_file';
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\FileKey';
+  const PLUGIN_ID = 'key_provider_file';
   const PLUGIN_TITLE = 'File Key';
   const PLUGIN_STORAGE = 'file';
 
@@ -27,7 +27,7 @@ class FileKeyTest extends KeyTypeTestBase {
     // Create a private key.
     $output = '';
     $this->keyFile = sys_get_temp_dir() . '/' . $this->getRandomGenerator()->word(10) . '.key';
-    $resource = openssl_pkey_new(['digest_alg' => 'sha1', 'private_key_bits' => 1024, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    $resource = openssl_pkey_new(['digest_alg' => 'sha1', 'private_key_bits' => 1024, 'private_key_provider' => OPENSSL_KEYTYPE_RSA]);
     openssl_pkey_export($resource, $output);
 
     file_put_contents($this->keyFile, $output);

--- a/tests/src/Plugin/KeyProvider/SimpleKeyTest.php
+++ b/tests/src/Plugin/KeyProvider/SimpleKeyTest.php
@@ -1,20 +1,20 @@
 <?php
 /**
  * @file
- * Provides \Drupal\Tests\key\Plugin\KeyType\SimpleKeyTest
+ * Provides \Drupal\Tests\key\Plugin\KeyProvider\SimpleKeyTest
  */
 
-namespace Drupal\Tests\key\Plugin\KeyType;
+namespace Drupal\Tests\key\Plugin\KeyProvider;
 
-use Drupal\Tests\key\KeyTypeTestBase;
+use Drupal\Tests\key\KeyProviderTestBase;
 
 /**
  * Test the SimpleKey plugin.
  */
-class SimpleKeyTest extends KeyTypeTestBase {
+class SimpleKeyTest extends KeyProviderTestBase {
 
-  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyType\SimpleKey';
-  const PLUGIN_ID = 'key_type_simple';
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\SimpleKey';
+  const PLUGIN_ID = 'key_provider_simple';
   const PLUGIN_TITLE = 'Simple Key';
   const PLUGIN_STORAGE = 'config';
 


### PR DESCRIPTION
The name "Key Type" has been changed to "Key Provider" when referencing the plugin that defines where a key is stored and how it is made available to the module. This is the same name used for the same purpose in the Drupal 7 version of Encrypt.