### PR TITLE
Added new permission for administering keys.

### DIFF
--- a/key.permissions.yml
+++ b/key.permissions.yml
@@ -1,0 +1,3 @@
+administer keys:
+  title: 'Administer keys'
+  description: 'Add, edit, and delete sitewide keys.'

--- a/key.routing.yml
+++ b/key.routing.yml
@@ -6,7 +6,7 @@ entity.key.collection:
     _entity_list: 'key'
     _title: 'Key Configuration'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer keys'
 
 entity.key.add_form:
   path: '/admin/config/system/key/add'
@@ -14,7 +14,7 @@ entity.key.add_form:
     _entity_form: 'key.add'
     _title: 'Add Key'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer keys'
 
 entity.key.edit_form:
   path: '/admin/config/system/key/{key}'
@@ -22,7 +22,7 @@ entity.key.edit_form:
     _entity_form: 'key.edit'
     _title: 'Edit Key'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer keys'
 
 entity.key.delete_form:
   path: '/admin/config/system/key/{key}/delete'
@@ -30,7 +30,7 @@ entity.key.delete_form:
     _entity_form: 'key.delete'
     _title: 'Delete Key'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer keys'
 
 
 key.key_config_form:

--- a/src/Entity/Key.php
+++ b/src/Entity/Key.php
@@ -25,7 +25,7 @@ use Drupal\key\KeyInterface;
  *     }
  *   },
  *   config_prefix = "key",
- *   admin_permission = "administer site configuration",
+ *   admin_permission = "administer keys",
  *   entity_keys = {
  *     "id" = "id",
  *     "label" = "label",

--- a/src/Tests/KeyService.php
+++ b/src/Tests/KeyService.php
@@ -23,8 +23,8 @@ class KeyService extends WebTestBase {
    */
   function testSimpleKeyService() {
 
-    // Create user with permission to create policy.
-    $user1 = $this->drupalCreateUser(array('administer site configuration'));
+    // Create user with permission to administer keys.
+    $user1 = $this->drupalCreateUser(array('administer keys'));
     $this->drupalLogin($user1);
 
     // Create new simple key.
@@ -83,8 +83,8 @@ class KeyService extends WebTestBase {
     $rpath = realpath(drupal_get_path('module','key').'/tests/assets/testkey.txt');
     $contents = file_get_contents($rpath);
 
-    // Create user with permission to create policy.
-    $user1 = $this->drupalCreateUser(array('administer site configuration'));
+    // Create user with permission to administer keys.
+    $user1 = $this->drupalCreateUser(array('administer keys'));
     $this->drupalLogin($user1);
 
     // Create a new file key.


### PR DESCRIPTION
The new 'administer keys' permission is used for Key administrative pages, instead of 'administer site configuration', as suggested in #26.