### PR TITLE
Set the correct type for Description field in schema.

### DIFF
--- a/config/schema/key.schema.yml
+++ b/config/schema/key.schema.yml
@@ -11,7 +11,7 @@ key.key.*:
     uuid:
       type: string
     description:
-      type: description
+      type: text
       label: 'Description'
     key_provider:
       type: string


### PR DESCRIPTION
The Description field had an invalid type in the Key schema. It should be set to 'text'.