### PR TITLE
Improved names of key providers

### DIFF
--- a/config/schema/key.schema.yml
+++ b/config/schema/key.schema.yml
@@ -31,11 +31,11 @@ key_provider:
 key.key_provider.plugin.*:
   type: key_provider
 
-key.key_provider.plugin.key_provider_simple:
+key.key_provider.plugin.config:
   type: key_provider
-  label: 'Simple Key'
+  label: 'Configuration'
   mapping:
-    simple_key_value:
+    key_value:
       type: string
       label: 'Key Value'
 

--- a/config/schema/key.schema.yml
+++ b/config/schema/key.schema.yml
@@ -11,7 +11,7 @@ key.key.*:
     uuid:
       type: string
     description:
-      type: description
+      type: text
       label: 'Description'
     key_provider:
       type: string

--- a/config/schema/key.schema.yml
+++ b/config/schema/key.schema.yml
@@ -39,10 +39,10 @@ key.key_provider.plugin.key_provider_simple:
       type: string
       label: 'Key Value'
 
-key.key_provider.plugin.key_provider_file:
+key.key_provider.plugin.file:
   type: key_provider
-  label: 'Simple Key'
+  label: 'File'
   mapping:
-    file_key_location:
+    file_location:
       type: string
       label: 'File Location'

--- a/src/Plugin/KeyProvider/ConfigKeyProvider.php
+++ b/src/Plugin/KeyProvider/ConfigKeyProvider.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\key\KeyProvider\SimpleKey.
+ * Contains Drupal\key\KeyProvider\ConfigKeyProvider.
  */
 
 
@@ -12,23 +12,23 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\key\KeyProviderBase;
 
 /**
- * Enforces a number of a type of character in passwords.
+ * Adds a key provider that allows a key to be stored in configuration.
  *
  * @KeyProvider(
- *   id = "key_provider_simple",
- *   title = @Translation("Simple Key"),
- *   description = @Translation("This key provider is stored within the Drupal database."),
+ *   id = "config",
+ *   title = @Translation("Configuration"),
+ *   description = @Translation("Allows a key to be stored in Drupal's configuration system."),
  *   storage_method = "config",
  * )
  */
-class SimpleKey extends KeyProviderBase {
+class ConfigKeyProvider extends KeyProviderBase {
 
   /**
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
     return [
-      'simple_key_value' => '',
+      'key_value' => '',
     ];
   }
 
@@ -36,12 +36,12 @@ class SimpleKey extends KeyProviderBase {
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['simple_key_value'] = array(
+    $form['key_value'] = array(
       '#type' => 'textarea',
-      '#title' => $this->t('Key Value'),
-      '#description' => $this->t('Enter the value of the key'),
+      '#title' => $this->t('Key value'),
+      '#description' => $this->t("Enter the key to save in Drupal's configuration system."),
       '#required' => TRUE,
-      '#default_value' => $this->getConfiguration()['simple_key_value'],
+      '#default_value' => $this->getConfiguration()['key_value'],
     );
     return $form;
   }
@@ -56,14 +56,14 @@ class SimpleKey extends KeyProviderBase {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['simple_key_value'] = $form_state->getValue('simple_key_value');
+    $this->configuration['key_value'] = $form_state->getValue('key_value');
   }
 
   /**
    * {@inheritdoc}
    */
   public function getKeyValue() {
-    return $this->configuration['simple_key_value'];
+    return $this->configuration['key_value'];
   }
 
 }

--- a/src/Plugin/KeyProvider/FileKeyProvider.php
+++ b/src/Plugin/KeyProvider/FileKeyProvider.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains Drupal\key\KeyProvider\FileKey.
+ * Contains Drupal\key\KeyProvider\FileKeyProvider.
  */
 
 
@@ -12,23 +12,23 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\key\KeyProviderBase;
 
 /**
- * Enforces a number of a type of character in passwords.
+ * Adds a key provider that allows a key to be stored in a file.
  *
  * @KeyProvider(
- *   id = "key_provider_file",
- *   title = @Translation("File Key"),
- *   description = @Translation("This key provider is stored within a file in the filesystem."),
+ *   id = "file",
+ *   title = @Translation("File"),
+ *   description = @Translation("Allows a key to be stored in a file within the filesystem."),
  *   storage_method = "file",
  * )
  */
-class FileKey extends KeyProviderBase {
+class FileKeyProvider extends KeyProviderBase {
 
   /**
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
     return [
-      'file_key_location' => '',
+      'file_location' => '',
     ];
   }
 
@@ -36,16 +36,16 @@ class FileKey extends KeyProviderBase {
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['file_key_location'] = array(
+    $form['file_location'] = array(
       '#type' => 'textfield',
-      '#title' => $this->t('Key Location'),
+      '#title' => $this->t('File location'),
       '#description' => $this->t('The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).', array(
         '%abs' => '/etc/keys/foobar.key',
         '%rel' => '../keys/foobar.key',
         '%str' => 'private://keys/foobar.key',
       )),
       '#required' => TRUE,
-      '#default_value' => $this->getConfiguration()['file_key_location'],
+      '#default_value' => $this->getConfiguration()['file_location'],
     );
 
     return $form;
@@ -55,11 +55,11 @@ class FileKey extends KeyProviderBase {
    * {@inheritdoc}
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $file = $form_state->getValue('file_key_location');
+    $file = $form_state->getValue('file_location');
 
     // Does the file exist and is it readable?
     if (!is_file($file) || !is_readable($file)) {
-      $form_state->setErrorByName('file_key_location', $this->t('File does not exist or is not readable.'));
+      $form_state->setErrorByName('file_location', $this->t('File does not exist or is not readable.'));
     }
   }
 
@@ -67,14 +67,14 @@ class FileKey extends KeyProviderBase {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['file_key_location'] = $form_state->getValue('file_key_location');
+    $this->configuration['file_location'] = $form_state->getValue('file_location');
   }
 
   /**
    * {@inheritdoc}
    */
   public function getKeyValue() {
-    $file = $this->configuration['file_key_location'];
+    $file = $this->configuration['file_location'];
 
     // Make sure the file exists and is readable.
     if (!is_file($file) || !is_readable($file)) {

--- a/src/Tests/KeyListBuilder.php
+++ b/src/Tests/KeyListBuilder.php
@@ -36,14 +36,14 @@ class KeyListBuilder extends WebTestBase {
     $test_string = 'testing 123 &*#';
     $this->drupalGet('admin/config/security/key/add');
     $edit = [
-      'key_provider' => 'key_provider_simple',
+      'key_provider' => 'config',
     ];
     $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
     $edit = [
       'id' => 'testing_key',
       'label' => 'Testing Key',
-      'key_provider' => 'key_provider_simple',
-      'key_settings[simple_key_value]' => $test_string,
+      'key_provider' => 'config',
+      'key_settings[key_value]' => $test_string,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 

--- a/src/Tests/KeyService.php
+++ b/src/Tests/KeyService.php
@@ -81,7 +81,7 @@ class KeyService extends WebTestBase {
   /**
    * Test getKeyValue functions.
    */
-  function testFileKeyService() {
+  function testFileKeyProviderService() {
     $rpath = realpath(drupal_get_path('module','key').'/tests/assets/testkey.txt');
     $contents = file_get_contents($rpath);
 
@@ -92,7 +92,7 @@ class KeyService extends WebTestBase {
     // Create a new file key.
     $this->drupalGet('admin/config/security/key/add');
     $edit = [
-      'key_provider' => 'key_provider_file',
+      'key_provider' => 'file',
     ];
     $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
@@ -100,8 +100,8 @@ class KeyService extends WebTestBase {
       'id' => 'testing_key_file',
       'label' => 'Testing Key File',
       'description' => 'A test of the file key provider.',
-      'key_provider' => 'key_provider_file',
-      'key_settings[file_key_location]' => $rpath,
+      'key_provider' => 'file',
+      'key_settings[file_location]' => $rpath,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
@@ -119,7 +119,7 @@ class KeyService extends WebTestBase {
     // Create a second new file key.
     $this->drupalGet('admin/config/security/key/add');
     $edit = [
-      'key_provider' => 'key_provider_file',
+      'key_provider' => 'file',
     ];
     $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
@@ -127,8 +127,8 @@ class KeyService extends WebTestBase {
       'id' => 'testing_key_file2',
       'label' => 'Testing Key File2',
       'description' => 'A second test of the file key provider.',
-      'key_provider' => 'key_provider_file',
-      'key_settings[file_key_location]' => $rpath,
+      'key_provider' => 'file',
+      'key_settings[file_location]' => $rpath,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 

--- a/src/Tests/KeyService.php
+++ b/src/Tests/KeyService.php
@@ -21,26 +21,26 @@ class KeyService extends WebTestBase {
   /**
    * Test getKeyValue functions.
    */
-  function testSimpleKeyService() {
+  function testConfigKeyProviderService() {
 
     // Create user with permission to administer keys.
     $user1 = $this->drupalCreateUser(array('administer keys'));
     $this->drupalLogin($user1);
 
-    // Create new simple key.
+    // Create new key using the Configuration key provider.
     $test_string = 'testing 123 &*#';
     $this->drupalGet('admin/config/security/key/add');
     $edit = [
-      'key_provider' => 'key_provider_simple',
+      'key_provider' => 'config',
     ];
     $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key',
       'label' => 'Testing Key',
-      'description' => 'A test of the simple key provider.',
-      'key_provider' => 'key_provider_simple',
-      'key_settings[simple_key_value]' => $test_string,
+      'description' => 'A test of the Configuration key provider.',
+      'key_provider' => 'config',
+      'key_settings[key_value]' => $test_string,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
@@ -53,29 +53,29 @@ class KeyService extends WebTestBase {
     $this->assertEqual($key_value_string, $test_string, 'The getKeyValue function is not properly processing');
 
     // Test getKeysByProvider service.
-    $keys = \Drupal::service('key_manager')->getKeysByProvider('key_provider_simple');
-    $this->assertEqual(count($keys), '1', 'The getKeysByProvider function is not returning 1 simple key');
+    $keys = \Drupal::service('key_manager')->getKeysByProvider('config');
+    $this->assertEqual(count($keys), '1', 'The getKeysByProvider function is not returning 1 config key');
 
-    // Create another simple key.
+    // Create another key using the Configuration key provider.
     $test_string = 'testing 12345678 (837#';
     $this->drupalGet('admin/config/security/key/add');
     $edit = [
-      'key_provider' => 'key_provider_simple',
+      'key_provider' => 'config',
     ];
     $this->drupalPostAjaxForm(NULL, $edit, 'key_provider');
 
     $edit = [
       'id' => 'testing_key2',
       'label' => 'Testing Key 2',
-      'description' => 'A second test of the simple key provider.',
-      'key_provider' => 'key_provider_simple',
-      'key_settings[simple_key_value]' => $test_string,
+      'description' => 'A second test of the Configuration key provider.',
+      'key_provider' => 'config',
+      'key_settings[key_value]' => $test_string,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
     // Test getKeysByProvider service.
-    $keys = \Drupal::service('key_manager')->getKeysByProvider('key_provider_simple');
-    $this->assertEqual(count($keys), '2', 'The getKeysByProvider function is not returning 2 simple keys');
+    $keys = \Drupal::service('key_manager')->getKeysByProvider('config');
+    $this->assertEqual(count($keys), '2', 'The getKeysByProvider function is not returning 2 config keys');
   }
 
   /**

--- a/tests/src/Entity/KeyEntityTest.php
+++ b/tests/src/Entity/KeyEntityTest.php
@@ -7,7 +7,7 @@
 namespace Drupal\Tests\key\Entity;
 
 use Drupal\key\Entity\Key;
-use Drupal\key\Plugin\KeyProvider\SimpleKey;
+use Drupal\key\Plugin\KeyProvider\ConfigKeyProvider;
 use Drupal\Tests\key\KeyTestBase;
 
 /**
@@ -19,7 +19,7 @@ class KeyEntityTest extends KeyTestBase {
 
   /**
    * @var []
-   *   Key settings to use for SimpleKey provider.
+   *   Key settings to use for Configuration key provider.
    */
   protected $key_settings;
 
@@ -29,17 +29,17 @@ class KeyEntityTest extends KeyTestBase {
    * @group key
    */
   public function testGetters() {
-    // Create a key entity using simple provider.
+    // Create a key entity using Configuration key provider.
     $values = [
       'key_id' => $this->getRandomGenerator()->word(15),
-      'key_provider' => 'key_provider_simple',
+      'key_provider' => 'config',
       'key_settings' => $this->key_settings,
     ];
     $key = new Key($values, 'key');
 
     $this->assertEquals($values['key_provider'], $key->getKeyProvider());
     $this->assertEquals($values['key_settings'], $key->getKeySettings());
-    $this->assertEquals($values['key_settings']['simple_key_value'], $key->getKeyValue());
+    $this->assertEquals($values['key_settings']['key_value'], $key->getKeyValue());
   }
 
   /**
@@ -49,12 +49,12 @@ class KeyEntityTest extends KeyTestBase {
     parent::setUp();
 
     $definition = [
-      'id' => 'key_provider_simple',
-      'title' => 'Simple Key',
+      'id' => 'config',
+      'title' => 'Configuration',
       'storage_method' => 'config'
     ];
-    $this->key_settings = ['simple_key_value' => $this->createToken()];
-    $plugin = new SimpleKey($this->key_settings, 'key_provider_simple', $definition);
+    $this->key_settings = ['key_value' => $this->createToken()];
+    $plugin = new ConfigKeyProvider($this->key_settings, 'config', $definition);
 
     // Mock the KeyProviderPluginManager service.
     $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderPluginManager')
@@ -65,11 +65,11 @@ class KeyEntityTest extends KeyTestBase {
       ->method('getDefinitions')
       ->willReturn([
         ['id' => 'file', 'title' => 'File', 'storage_method' => 'file'],
-        ['id' => 'key_provider_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
+        ['id' => 'config', 'title' => 'Configuration', 'storage_method' => 'config']
       ]);
     $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_provider_simple', $this->key_settings)
+      ->with('config', $this->key_settings)
       ->willReturn($plugin);
     $this->container->set('plugin.manager.key.key_provider', $this->KeyProviderManager);
 

--- a/tests/src/Entity/KeyEntityTest.php
+++ b/tests/src/Entity/KeyEntityTest.php
@@ -64,7 +64,7 @@ class KeyEntityTest extends KeyTestBase {
     $this->KeyProviderManager->expects($this->any())
       ->method('getDefinitions')
       ->willReturn([
-        ['id' => 'key_provider_file', 'title' => 'File Key', 'storage_method' => 'file'],
+        ['id' => 'file', 'title' => 'File', 'storage_method' => 'file'],
         ['id' => 'key_provider_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
       ]);
     $this->KeyProviderManager->expects($this->any())

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -5,7 +5,7 @@
 
 namespace Drupal\Tests\key;
 
-use Drupal\key\Plugin\KeyProvider\SimpleKey;
+use Drupal\key\Plugin\KeyProvider\ConfigKeyProvider;
 use Drupal\key\Entity\Key;
 use Drupal\key\KeyManager;
 
@@ -31,13 +31,13 @@ class KeyManagerTest extends KeyTestBase {
    * Provide test values for default key content.
    */
   public function defaultKeyContentProvider() {
-    $defaults = ['simple_key_value' => $this->createToken()];
+    $defaults = ['key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_provider_Simple',
-      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
-      'title' => 'Simple Key',
+      'id' => 'config',
+      'class' => 'Drupal\key\Plugin\KeyProvider\ConfigKeyProvider',
+      'title' => 'Configuration',
     ];
-    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
+    $KeyProvider = new ConfigKeyProvider($defaults, 'config', $definition);
 
     return [
       [$defaults, $KeyProvider]
@@ -103,13 +103,13 @@ class KeyManagerTest extends KeyTestBase {
     // Make the key provider plugin manager return a plugin instance.
     $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_provider_simple', $defaults)
+      ->with('config', $defaults)
       ->willReturn($KeyProvider);
 
     $this->key->set('key_settings', $defaults);
 
     $settings = $this->keyManager->getKeyValue($this->key_id);
-    $this->assertEquals($defaults['simple_key_value'], $settings);
+    $this->assertEquals($defaults['key_value'], $settings);
   }
 
   /**
@@ -119,29 +119,29 @@ class KeyManagerTest extends KeyTestBase {
    */
   public function testGetKeysByProvider() {
     // Create a key provider plugin to play with.
-    $defaults = ['simple_key_value' => $this->createToken()];
+    $defaults = ['key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_provider_Simple',
-      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
-      'title' => 'Simple Key',
+      'id' => 'config',
+      'class' => 'Drupal\key\Plugin\KeyProvider\ConfigKeyProvider',
+      'title' => 'Configuration',
     ];
-    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
+    $KeyProvider = new ConfigKeyProvider($defaults, 'config', $definition);
 
     // Make the key provider plugin manager return a plugin instance.
     $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_provider_simple', $defaults)
+      ->with('config', $defaults)
       ->willReturn($KeyProvider);
 
     // Mock the loadByProperties method in entity manager.
     $this->configStorage->expects($this->any())
       ->method('loadByProperties')
-      ->with(['key_provider' => 'key_provider_simple'])
+      ->with(['key_provider' => 'config'])
       ->willReturn([$this->key_id => $this->key]);
 
     $this->key->set('key_settings', $defaults);
 
-    $keys = $this->keyManager->getKeysByProvider('key_provider_simple');
+    $keys = $this->keyManager->getKeysByProvider('config');
     $this->assertEquals($this->key, $keys[$this->key_id]);
   }
 
@@ -152,24 +152,24 @@ class KeyManagerTest extends KeyTestBase {
    */
   public function testGetKeysByStorageMethod() {
     // Create a key provider plugin to play with.
-    $defaults = ['simple_key_value' => $this->createToken()];
+    $defaults = ['key_value' => $this->createToken()];
     $definition = [
-      'id' => 'key_provider_Simple',
-      'class' => 'Drupal\key\Plugin\KeyProvider\SimpleKey',
-      'title' => 'Simple Key',
+      'id' => 'config',
+      'class' => 'Drupal\key\Plugin\KeyProvider\ConfigKeyProvider',
+      'title' => 'Configuration',
     ];
-    $KeyProvider = new SimpleKey($defaults, 'key_provider_simple', $definition);
+    $KeyProvider = new ConfigKeyProvider($defaults, 'config', $definition);
 
     // Mock the loadByProperties method in entity manager.
     $this->configStorage->expects($this->any())
       ->method('loadByProperties')
-      ->with(['key_provider' => 'key_provider_simple'])
+      ->with(['key_provider' => 'config'])
       ->willReturn([$this->key_id => $this->key]);
 
     // Make the key provider plugin manager return a plugin instance.
     $this->KeyProviderManager->expects($this->any())
       ->method('createInstance')
-      ->with('key_provider_simple', $defaults)
+      ->with('config', $defaults)
       ->willReturn($KeyProvider);
 
     $this->key->set('key_settings', $defaults);
@@ -187,7 +187,7 @@ class KeyManagerTest extends KeyTestBase {
     $this->key_id = $this->getRandomGenerator()->word(15);
     $defaults = [
       'key_id' => $this->key_id,
-      'key_provider' => 'key_provider_simple'
+      'key_provider' => 'config'
     ];
     $this->key = new Key($defaults, 'key');
 
@@ -213,7 +213,7 @@ class KeyManagerTest extends KeyTestBase {
       ->method('getDefinitions')
       ->willReturn([
         ['id' => 'file', 'title' => 'File', 'storage_method' => 'file'],
-        ['id' => 'key_provider_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
+        ['id' => 'config', 'title' => 'Configuration', 'storage_method' => 'config']
       ]);
 
     $this->container->set('plugin.manager.key.key_provider', $this->KeyProviderManager);

--- a/tests/src/KeyManagerTest.php
+++ b/tests/src/KeyManagerTest.php
@@ -212,7 +212,7 @@ class KeyManagerTest extends KeyTestBase {
     $this->KeyProviderManager->expects($this->any())
       ->method('getDefinitions')
       ->willReturn([
-        ['id' => 'key_provider_file', 'title' => 'File Key', 'storage_method' => 'file'],
+        ['id' => 'file', 'title' => 'File', 'storage_method' => 'file'],
         ['id' => 'key_provider_simple', 'title' => 'Simple Key', 'storage_method' => 'config']
       ]);
 

--- a/tests/src/Plugin/KeyProvider/ConfigKeyProviderTest.php
+++ b/tests/src/Plugin/KeyProvider/ConfigKeyProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Provides \Drupal\Tests\key\Plugin\KeyProvider\SimpleKeyTest
+ * Provides \Drupal\Tests\key\Plugin\KeyProvider\ConfigKeyProviderTest
  */
 
 namespace Drupal\Tests\key\Plugin\KeyProvider;
@@ -9,13 +9,13 @@ namespace Drupal\Tests\key\Plugin\KeyProvider;
 use Drupal\Tests\key\KeyProviderTestBase;
 
 /**
- * Test the SimpleKey plugin.
+ * Test the ConfigKeyProvider plugin.
  */
-class SimpleKeyTest extends KeyProviderTestBase {
+class ConfigKeyProviderTest extends KeyProviderTestBase {
 
-  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\SimpleKey';
-  const PLUGIN_ID = 'key_provider_simple';
-  const PLUGIN_TITLE = 'Simple Key';
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\ConfigKeyProvider';
+  const PLUGIN_ID = 'config';
+  const PLUGIN_TITLE = 'Configuration';
   const PLUGIN_STORAGE = 'config';
 
   /**
@@ -28,16 +28,16 @@ class SimpleKeyTest extends KeyProviderTestBase {
     $form = [];
 
     $form['key_settings'] = $this->plugin->buildConfigurationForm($form, $this->form_state);
-    $this->assertNotNull($form['key_settings']['simple_key_value']);
-    $this->assertEmpty($form['key_settings']['simple_key_value']['#default_value']);
+    $this->assertNotNull($form['key_settings']['key_value']);
+    $this->assertEmpty($form['key_settings']['key_value']['#default_value']);
 
     // Set the form state value, and simulate a form submission.
-    $this->form_state->setValues(['simple_key_value' => $value]);
+    $this->form_state->setValues(['key_value' => $value]);
     $this->plugin->validateConfigurationForm($form, $this->form_state);
     $this->assertEmpty($this->form_state->getErrors());
 
     // Submission.
     $this->plugin->submitConfigurationForm($form, $this->form_state);
-    $this->assertEquals($value, $this->plugin->getConfiguration()['simple_key_value']);
+    $this->assertEquals($value, $this->plugin->getConfiguration()['key_value']);
   }
 }

--- a/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
+++ b/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
@@ -58,7 +58,7 @@ class FileKeyProviderTest extends KeyProviderTestBase {
     $this->translationManager->expects($this->any())
       ->method('translate')
       ->withConsecutive(
-        ['Key Location'],
+        ['File Location'],
         ['The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).'],
         ['File does not exist or is not readable.']
       )

--- a/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
+++ b/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
@@ -58,7 +58,7 @@ class FileKeyProviderTest extends KeyProviderTestBase {
     $this->translationManager->expects($this->any())
       ->method('translate')
       ->withConsecutive(
-        ['File Location'],
+        ['File location'],
         ['The location of the file in which the key will be stored. The path may be absolute (e.g., %abs), relative to the Drupal directory (e.g., %rel), or defined using a stream wrapper (e.g., %str).'],
         ['File does not exist or is not readable.']
       )

--- a/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
+++ b/tests/src/Plugin/KeyProvider/FileKeyProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Provides \Drupal\Tests\key\Plugin\KeyProvider\FileKeyTest
+ * Provides \Drupal\Tests\key\Plugin\KeyProvider\FileKeyProviderTest
  */
 
 namespace Drupal\Tests\key\Plugin\KeyProvider;
@@ -9,13 +9,13 @@ namespace Drupal\Tests\key\Plugin\KeyProvider;
 use Drupal\Tests\key\KeyProviderTestBase;
 
 /**
- * Test the FileKey plugin.
+ * Test the FileKeyProvider plugin.
  */
-class FileKeyTest extends KeyProviderTestBase {
+class FileKeyProviderTest extends KeyProviderTestBase {
 
-  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\FileKey';
-  const PLUGIN_ID = 'key_provider_file';
-  const PLUGIN_TITLE = 'File Key';
+  const PLUGIN_CLASS = '\Drupal\key\Plugin\KeyProvider\FileKeyProvider';
+  const PLUGIN_ID = 'file';
+  const PLUGIN_TITLE = 'File';
   const PLUGIN_STORAGE = 'file';
 
   /**
@@ -65,22 +65,22 @@ class FileKeyTest extends KeyProviderTestBase {
       ->willReturn('File does not exist or is not readable.');
 
     $form['key_settings'] = $this->plugin->buildConfigurationForm($form, $this->form_state);
-    $this->assertNotNull($form['key_settings']['file_key_location']);
+    $this->assertNotNull($form['key_settings']['file_location']);
 
     // Test that the file is validated.
-    $this->form_state->setValues(['file_key_location' => 'bogus']);
+    $this->form_state->setValues(['file_location' => 'bogus']);
     $this->plugin->validateConfigurationForm($form, $this->form_state);
-    $this->assertEquals('File does not exist or is not readable.', $this->form_state->getErrors()['file_key_location']);
+    $this->assertEquals('File does not exist or is not readable.', $this->form_state->getErrors()['file_location']);
 
     // Set the form state value, and simulate a form submission.
     $this->form_state->clearErrors();
-    $this->form_state->setValues(['file_key_location' => $this->keyFile]);
+    $this->form_state->setValues(['file_location' => $this->keyFile]);
     $this->plugin->validateConfigurationForm($form, $this->form_state);
     $this->assertEmpty($this->form_state->getErrors());
 
     // Submission.
     $this->plugin->submitConfigurationForm($form, $this->form_state);
-    $this->assertEquals($this->keyFile, $this->plugin->getConfiguration()['file_key_location']);
+    $this->assertEquals($this->keyFile, $this->plugin->getConfiguration()['file_location']);
 
     // Make sure that the file contents are valid.
     $resource = openssl_pkey_get_private($this->plugin->getKeyValue());


### PR DESCRIPTION
This addresses Issue #39.

The names of the built-in key providers have changed as follows:
- "SimpleKey" is now "Configuration"
- "FileKey" is now "File"