### PR TITLE
Display provider title in key list.

### DIFF
--- a/src/Controller/KeyListBuilder.php
+++ b/src/Controller/KeyListBuilder.php
@@ -8,12 +8,37 @@
 namespace Drupal\key\Controller;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\key\KeyProviderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a listing of Key.
  */
 class KeyListBuilder extends ConfigEntityListBuilder {
+
+  private $keyProviderPluginManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity.manager')->getStorage($entity_type->id()),
+      $container->get('plugin.manager.key.key_provider')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, KeyProviderInterface $key_provider_plugin_manager) {
+    parent::__construct($entity_type, $storage);
+    $this->keyProviderPluginManager = $key_provider_plugin_manager;
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -33,8 +58,7 @@ class KeyListBuilder extends ConfigEntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $entity->label();
-    // TODO: Display the provider label, instead of the machine name.
-    $row['provider'] = $entity->getKeyProvider();
+    $row['provider'] = $this->keyProviderPluginManager->getDefinition($entity->getKeyProvider())['title'];
     $row['service_default'] = ($entity->getServiceDefault())?"Yes":"No";
     return $row + parent::buildRow($entity);
   }

--- a/src/Controller/KeyListBuilder.php
+++ b/src/Controller/KeyListBuilder.php
@@ -8,9 +8,10 @@
 namespace Drupal\key\Controller;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\key\KeyProviderInterface;
+use Drupal\key\KeyProviderPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,8 +35,9 @@ class KeyListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeInterface $entity_type, ConfigEntityStorage $storage, KeyProviderInterface $key_provider_plugin_manager) {
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, KeyProviderPluginManager $key_provider_plugin_manager) {
     parent::__construct($entity_type, $storage);
+
     $this->keyProviderPluginManager = $key_provider_plugin_manager;
   }
 

--- a/src/Controller/KeyListBuilder.php
+++ b/src/Controller/KeyListBuilder.php
@@ -34,7 +34,7 @@ class KeyListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, KeyProviderInterface $key_provider_plugin_manager) {
+  public function __construct(EntityTypeInterface $entity_type, ConfigEntityStorage $storage, KeyProviderInterface $key_provider_plugin_manager) {
     parent::__construct($entity_type, $storage);
     $this->keyProviderPluginManager = $key_provider_plugin_manager;
   }


### PR DESCRIPTION
This finishes #63 by displaying the title of each key's provider, instead of its id, on the key list page.