### PR TITLE
Cleaned up and enhanced Key Provider Manager.

### DIFF
--- a/key.api.php
+++ b/key.api.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * Hooks specific to the Key module.
+ */
+
+/**
+ * Alter the definitions of Key Provider plugins.
+ *
+ * This hook is invoked by KeyProviderManager::__construct().
+ *
+ * @param array $key_providers
+ *   An array containing all of the key provider plugin definitions.
+ */
+function hook_key_provider_info_alter(array &$key_providers) {
+  // Swap the classes used for the Configuration and File key providers.
+  $key_providers['config']['class'] = 'Drupal\key\Plugin\KeyProvider\FileKeyProvider';
+  $key_providers['file']['class'] = 'Drupal\key\Plugin\KeyProvider\ConfigKeyProvider';
+}

--- a/key.services.yml
+++ b/key.services.yml
@@ -3,5 +3,5 @@ services:
     class: Drupal\key\KeyRepository
     arguments: ['@entity.manager', '@config.factory', '@plugin.manager.key.key_provider']
   plugin.manager.key.key_provider:
-    class: Drupal\key\KeyProviderPluginManager
+    class: Drupal\key\KeyProviderManager
     parent: default_plugin_manager

--- a/src/KeyProviderManager.php
+++ b/src/KeyProviderManager.php
@@ -1,18 +1,20 @@
 <?php
 /**
  * @file
- * Contains Drupal\key\KeyProviderPluginManager.
+ * Contains Drupal\key\KeyProviderManager.
  */
 
 namespace Drupal\key;
 
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
 
 
-class KeyProviderPluginManager extends \Drupal\Core\Plugin\DefaultPluginManager {
+class KeyProviderManager extends DefaultPluginManager {
+
   /**
-   * Constructs a new KeyProviderPluginManager.
+   * Constructs a new KeyProviderManager.
    *
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths
@@ -24,7 +26,7 @@ class KeyProviderPluginManager extends \Drupal\Core\Plugin\DefaultPluginManager 
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct('Plugin/KeyProvider', $namespaces, $module_handler, 'Drupal\key\KeyProviderInterface', 'Drupal\key\Annotation\KeyProvider');
-    $this->alterInfo('key_constraint_info');
+    $this->alterInfo('key_provider_info');
     $this->setCacheBackend($cache_backend, 'key_provider');
   }
 

--- a/tests/src/Entity/KeyEntityTest.php
+++ b/tests/src/Entity/KeyEntityTest.php
@@ -56,8 +56,8 @@ class KeyEntityTest extends KeyTestBase {
     $this->key_settings = ['key_value' => $this->createToken()];
     $plugin = new ConfigKeyProvider($this->key_settings, 'config', $definition);
 
-    // Mock the KeyProviderPluginManager service.
-    $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderPluginManager')
+    // Mock the KeyProviderManager service.
+    $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderManager')
       ->disableOriginalConstructor()
       ->getMock();
 

--- a/tests/src/KeyRepositoryTest.php
+++ b/tests/src/KeyRepositoryTest.php
@@ -207,8 +207,8 @@ class KeyRepositoryTest extends KeyTestBase {
       ->with($this->key_id)
       ->willReturn($this->key);
 
-    // Mock the KeyProviderPluginManager service.
-    $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderPluginManager')
+    // Mock the KeyProviderManager service.
+    $this->KeyProviderManager = $this->getMockBuilder('\Drupal\key\KeyProviderManager')
       ->disableOriginalConstructor()
       ->getMock();
 


### PR DESCRIPTION
This PR contains the following modifications to the Key Provider Manager:

- Changed name to KeyProviderManager from KeyProviderPluginManager to be simpler and to match a common pattern in core (BlockManager and EntityTypeManager, for example)
- Fixed unnecessary fully qualified class name (\Drupal\Core\Plugin\DefaultPluginManager)
- Changed alter info hook name to hook_key_provider_info_alter() from hook_key_constraint_info_alter()
- Added API file (key.api.php) with example of implementation of hook_key_provider_info_alter()
