### PR TITLE
set key entity in form_state when building form

### DIFF
--- a/src/Form/KeyForm.php
+++ b/src/Form/KeyForm.php
@@ -50,6 +50,7 @@ class KeyForm extends EntityForm {
 
     /** @var $key \Drupal\key\KeyInterface */
     $key = $this->entity;
+    $form_state->set('key_entity', $key);
     $form['#tree'] = TRUE;
     $form['label'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
Simple change to allow plugins to compute default key values based on the key entity being edited.
